### PR TITLE
Mudança no parâmetro de onDelete na tabela de Logs

### DIFF
--- a/src/modules/minutes/services/DeleteScheduleMeetingService.ts
+++ b/src/modules/minutes/services/DeleteScheduleMeetingService.ts
@@ -46,7 +46,7 @@ class DeleteScheduleMeetingService {
     await this.logsRepository.create({
       minute_id: minute.id,
       user_id: user,
-      registered_action: `O agendamento para a reunião ${minute.project} foi excluído por ${minute.user_id}.`,
+      registered_action: 'Agendamento cancelado',
     });
 
     await this.minutesRepository.deleteScheduleMeeting(minute);

--- a/src/shared/infra/typeorm/migrations/1619388829938-CreteLogs.ts
+++ b/src/shared/infra/typeorm/migrations/1619388829938-CreteLogs.ts
@@ -63,7 +63,7 @@ export class CreteLogs1619388829938 implements MigrationInterface {
             referencedTableName: 'minutes',
             referencedColumnNames: ['id'],
             columnNames: ['minute_id'],
-            onDelete: 'CASCADE',
+            onDelete: 'SET NULL',
             onUpdate: 'CASCADE',
           },
         ],


### PR DESCRIPTION
Mudei o parâmetro de onDelete para Set Null na tabela de Logs na FK minuteId, pois quando eu excluía o agendamento, o Log também era excluído.